### PR TITLE
Add prevailing_rule/2 and matches_explicit_rule?/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ iex(3)> PublicSuffix.public_suffix("mysite.foo.bar.com")
 "com"
 iex(4)> PublicSuffix.public_suffix("mysite.foo.bar.co.uk")
 "co.uk"
+iex(5)> PublicSuffix.prevailing_rule("mysite.foo.bar.com")
+"com"
+iex(6)> PublicSuffix.prevailing_rule("mysite.example")
+"*"
+iex(7)> PublicSuffix.matches_explicit_rule?("mysite.foo.bar.com")
+true
+iex(8)> PublicSuffix.matches_explicit_rule?("mysite.example")
+false
 ```
 
 The publicsuffix.org data file contains both official ICANN records

--- a/test/public_suffix_test.exs
+++ b/test/public_suffix_test.exs
@@ -28,6 +28,87 @@ defmodule PublicSuffix.PublicSuffixTest do
     end
   end
 
+  test_cases_prevailing_private = [
+    {"exact match", "foo.github.io", "github.io", "io"},
+    {"wildcard", "foo.bar.api.githubcloud.com", "*.api.githubcloud.com", "com"},
+  ]
+
+  for {rule_type, input, expected_with_private, expected_without_private} <- test_cases_prevailing_private do
+    @input input
+    @expected_with_private expected_with_private
+    @expected_without_private expected_without_private
+
+    test "`prevailing_rule` includes private domains by default (#{rule_type})" do
+      assert prevailing_rule(@input) == @expected_with_private
+    end
+
+    test "`prevailing_rule` includes private domains if passed `ignore_private: false` (#{rule_type})" do
+      assert prevailing_rule(@input, ignore_private: false) == @expected_with_private
+    end
+
+    test "`prevailing_rule` excludes private domains if passed `ignore_private: true` (#{rule_type})" do
+      assert prevailing_rule(@input, ignore_private: true) == @expected_without_private
+    end
+  end
+
+  test_cases_prevailing = [
+    {"leading dot", ".com", nil},
+    {"unlisted TLD", "example", "*"},
+    {"unlisted TLD", "example.example", "*"},
+    {"TLD with only 1 rule", "biz", "biz"},
+    {"TLD with only 1 rule", "domain.biz", "biz"},
+    {"TLD with some 2-level rules", "uk.com", "uk.com"},
+    {"TLD with some 2-level rules", "example.uk.com", "uk.com"},
+    {"TLD with only 1 (wildcard) rule", "mm", "*"},
+    {"TLD with only 1 (wildcard) rule", "c.mm", "*.mm"},
+    {"TLD with only 1 (wildcard) rule", "b.c.mm", "*.mm"},
+    {"more complex TLD", "kyoto.jp", "kyoto.jp"},
+    {"more complex TLD", "test.kyoto.jp", "kyoto.jp"},
+    {"more complex TLD", "ide.kyoto.jp", "ide.kyoto.jp"},
+    {"more complex TLD", "b.ide.kyoto.jp", "ide.kyoto.jp"},
+    {"more complex TLD", "a.b.ide.kyoto.jp", "ide.kyoto.jp"},
+    {"more complex TLD", "c.kobe.jp", "*.kobe.jp"},
+    {"more complex TLD", "b.c.kobe.jp", "*.kobe.jp"},
+    {"more complex TLD", "city.kobe.jp", "!city.kobe.jp"},
+    {"more complex TLD", "www.city.kobe.jp", "!city.kobe.jp"},
+    {"TLD with a wildcard rule and exceptions", "ck", "*"},
+    {"TLD with a wildcard rule and exceptions", "test.ck", "*.ck"},
+    {"TLD with a wildcard rule and exceptions", "b.test.ck", "*.ck"},
+    {"TLD with a wildcard rule and exceptions", "www.ck", "!www.ck"},
+    {"TLD with a wildcard rule and exceptions", "www.www.ck", "!www.ck"},
+  ]
+
+  for {rule_type, input, expected_output} <- test_cases_prevailing do
+    @input input
+    @expected_output expected_output
+
+    test "`prevailing_rule` returns `#{to_string(expected_output)}` if passed `#{input}` (#{rule_type})" do
+      assert prevailing_rule(@input) == @expected_output
+    end
+  end
+
+  test_cases_matches_explicit = [
+    {"listed TLD only", "com", true},
+    {"TLD with only 1 (wildcard) rule", "mm", false},
+    {"TLD with only 1 (wildcard) rule", "b.mm", true},
+    {"TLD with a wildcard rule and exceptions", "ck", false},
+    {"TLD with a wildcard rule and exceptions", "b.ck", true},
+    {"TLD with a wildcard rule and exceptions", "www.ck", true},
+    {"domain with leading dot", ".com", false},
+    {"unlisted TLD", "example", false},
+    {"empty string", "", false},
+    {"nil", nil, false},
+  ]
+
+  for {rule_type, input, expected_output} <- test_cases_matches_explicit do
+    @input input
+    @expected_output expected_output
+
+    test "`matches_explicit_rule?` returns `#{to_string(expected_output)}` if passed `#{input}` (#{rule_type})" do
+      assert matches_explicit_rule?(@input) == @expected_output
+    end
+  end
+
   test "unicode domains are correctly NFKC normalized when punycoding them" do
     # Both of these strings are different unicode forms of "ábc.co.uk".
     # The example came from:


### PR DESCRIPTION
This fixes  #15 by adding `prevailing_rule/2` (returns prevailing rule of domain) and `matches_explicit_rule?` (checks whether domain matches explicit rule). E.g.:

```
iex(1)> PublicSuffix.prevailing_rule(".com")                 
nil
iex(2)> PublicSuffix.prevailing_rule("foobar.com")
"com"
iex(3)> PublicSuffix.prevailing_rule("foobar.co.uk")
"co.uk"
iex(4)> PublicSuffix.prevailing_rule("com")         
"com"
iex(5)> PublicSuffix.prevailing_rule("foobar.example")
"*"
iex(6)> PublicSuffix.prevailing_rule("ck")            
"*"
iex(7)> PublicSuffix.prevailing_rule("www.ck")
"ck"
iex(8)> PublicSuffix.prevailing_rule("foobar.net.ck")
"net.ck"
iex(9)> PublicSuffix.matches_explicit_rule?(".com")          
false
iex(10)> PublicSuffix.matches_explicit_rule?("foobar.com")
true
iex(11)> PublicSuffix.matches_explicit_rule?("ck")        
false
iex(12)> PublicSuffix.matches_explicit_rule?("www.ck")
true
iex(13)> PublicSuffix.matches_explicit_rule?("foobar.net.ck")
true
iex(14)> PublicSuffix.matches_explicit_rule?("foobar.example")
false
```

Tests also added. `prevailing_rule` is tested in `test/generated_test_cases.exs`. It should return the same as `public_suffix`, except for a few cases (e.g. when the domain is unlisted) where it should return `"*"`; these are handled separately in `test/public_suffix_test.exs`, where there are also some tests for `matches_explicit_rule?`.

(Disclaimer: I'd never touched ExUnit before but I *think* it's OK :))