### PR TITLE
Remove unneeded `mix local.rebar --force`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ otp_release:
   - 18.1
 elixir:
   - 1.2.6
-  - 1.3.0
-before_install: "mix local.rebar --force"
+  - 1.3.2
 script: "script/ci_build"


### PR DESCRIPTION
Travis does this automatically now.

From https://docs.travis-ci.com/user/languages/elixir/#Default-commands:

> By default, the install command is

> mix local.rebar --force # for Elixir 1.3.0 and up
> mix local.hex --force
> mix deps.get

Also, bump to Elixir 1.3.2.