### PR TITLE
Update idna dependency range

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ false
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+The package can be installed as:
 
   1. Add public_suffix to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:public_suffix, "~> 0.1.0"}]
+          [{:public_suffix, "~> 0.5.0"}]
         end
 
-  2. Ensure public_suffix is started before your application:
+  2. If using Elixir < 1.4, then ensure public_suffix is started before your application:
 
         def application do
           [applications: [:public_suffix]]

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule PublicSuffix.Mixfile do
 
   defp deps do
     [
-      {:idna, ">= 1.2.0 and < 3.0.0"},
+      {:idna, ">= 1.2.0 and < 6.0.0"},
       # ex_doc and earmark are necessary to publish docs to hexdocs.pm.
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,6 @@
-%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+%{
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []}}
+  "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+}


### PR DESCRIPTION
The latest version of hackney requires 5.0.2 so an update to publicsuffix-elixir is needed to maintain compatability.

As far as I can tell there are no breaking changes in idna. I've raised an issue to confirm this: https://github.com/benoitc/erlang-idna/issues/23
Although all the tests pass locally.

Also update version listed in the docs (along with installation instructions).