### PR TITLE
Fix elixir 1 8 warnings (and require Elixir 1.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 sudo: false
 language: elixir
-otp_release:
-  - 18.1
-elixir:
-  - 1.2.6
-  - 1.3.2
+matrix:
+  include:
+  - name: "1.5.0/otp18"
+    elixir: 1.5.0
+    otp_release: 18.1
+  - name: "1.6.6/otp19"
+    elixir: 1.6.6
+    otp_release: 19.3.6.9
+  - name: "1.8.0/otp20"
+    elixir: 1.8.0
+    otp_release: 20.3.8.9
 script: "script/ci_build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     otp_release: 18.1
   - name: "1.6.6/otp19"
     elixir: 1.6.6
-    otp_release: 19.3.6.9
+    otp_release: 19.3
   - name: "1.8.0/otp20"
     elixir: 1.8.0
-    otp_release: 20.3.8.9
+    otp_release: 20.3
 script: "script/ci_build"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unrealeased
+
+* Fix warnings up to Elixir v1.8.0
+  * Require Elixir 1.5
+
 ### 0.6.0 / 2018-02-28
 [Full Changelog](https://github.com/seomoz/publicsuffix-elixir/compare/v0.5.0...v0.4.0)
 

--- a/lib/public_suffix/remote_file_fetcher.ex
+++ b/lib/public_suffix/remote_file_fetcher.ex
@@ -10,7 +10,7 @@ defmodule PublicSuffix.RemoteFileFetcher do
     :ssl.start
 
     url
-    |> to_char_list
+    |> to_charlist()
     |> :httpc.request
     |> case do
          {:ok, {{_, 200, _}, _headers, body}} -> {:ok, to_string(body)}

--- a/lib/public_suffix/rules_parser.ex
+++ b/lib/public_suffix/rules_parser.ex
@@ -31,18 +31,18 @@ defmodule PublicSuffix.RulesParser do
       # contains a rule."
       |> Stream.reject(&(&1 =~ ~r/^\s*$/ || String.starts_with?(&1, "//")))
       # "Each line is only read up to the first whitespace"
-      |> Stream.map(&String.rstrip/1)
+      |> Stream.map(&String.trim_trailing/1)
       |> Stream.flat_map(fn rule -> [rule, punycode_domain(rule)] end)
       # "An exclamation mark (!) at the start of a rule marks an exception to a
       # previous wildcard rule."
-      |> Enum.partition(&String.starts_with?(&1, "!"))
+      |> Enum.split_with(&String.starts_with?(&1, "!"))
 
     # TODO: "Wildcards are not restricted to appear only in the leftmost position"
-    {wild_card_rules, exact_match_rules} = Enum.partition(normal_rules, &String.starts_with?(&1, "*."))
+    {wild_card_rules, exact_match_rules} = Enum.split_with(normal_rules, &String.starts_with?(&1, "*."))
 
     exception_rules =
       exception_rules
-      |> Stream.map(&String.lstrip(&1, ?!))
+      |> Stream.map(&String.trim_leading(&1, "!"))
       |> to_domain_label_map(type)
 
     exact_match_rules = to_domain_label_map(exact_match_rules, type)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PublicSuffix.Mixfile do
   def project do
     [app: :public_suffix,
      version: "0.6.0",
-     elixir: "~> 1.2",
+     elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      aliases: aliases(),

--- a/test/configuration_test.exs
+++ b/test/configuration_test.exs
@@ -21,14 +21,14 @@ defmodule PublicSuffix.ConfigurationTest do
 
     on_exit fn ->
       # restore things...
-      recompile_lib
+      recompile_lib()
       File.cp!(backup_file_name, cached_file_name)
       File.rm_rf!(temp_dir)
     end
   end
 
   test "compiles using a newly fetched copy of the rules file if so configured" do
-    recompile_lib
+    recompile_lib()
     assert get_public_suffix("foo.publicsuffix.elixir") == "publicsuffix.elixir"
     recompile_lib [{"PUBLIC_SUFFIX_DOWNLOAD_DATA_ON_COMPILE", "true"}]
     assert get_public_suffix("foo.publicsuffix.elixir") == "elixir"
@@ -37,7 +37,7 @@ defmodule PublicSuffix.ConfigurationTest do
   defp get_public_suffix(domain) do
     expression = "#{inspect domain} |> PublicSuffix.public_suffix |> IO.puts"
     assert {result, 0} = System.cmd "mix", ["run", "-e", expression]
-    result |> String.strip |> String.split("\n") |> List.last
+    result |> String.trim() |> String.split("\n") |> List.last
   end
 
   defp recompile_lib(env \\ []) do

--- a/test/generated_cases_test.exs
+++ b/test/generated_cases_test.exs
@@ -12,12 +12,12 @@ defmodule PublicSuffix.TestCaseGenerator do
     |> Stream.drop(@header_line_count)
     # Match on descriptive comment lines (which go before the test cases to which they apply)
     |> Stream.chunk_by(fn {line, _index} -> String.starts_with?(line, "// ") end)
-    |> Stream.chunk(2) # provides chunks of comment plus test cases matching the comment
+    |> Stream.chunk_every(2) # provides chunks of comment plus test cases matching the comment
     |> Stream.flat_map(&parse_group/1)
   end
 
   defp parse_group([[{"// " <> group_description, _}], test_cases]) do
-    group_description = String.rstrip(group_description, ?.)
+    group_description = String.trim_trailing(group_description, ".")
 
     test_cases
     |> Stream.with_index
@@ -41,7 +41,7 @@ defmodule PublicSuffix.TestCaseGenerator do
   end
 
   defp parse_arg("null"), do: nil
-  defp parse_arg(string), do: String.strip(string, ?')
+  defp parse_arg(string), do: String.trim(string, "'")
 
   defp public_suffix_output(nil, nil), do: nil
   # Inputs with a leading dot are a special case: the output should always be `nil`.
@@ -53,7 +53,7 @@ defmodule PublicSuffix.TestCaseGenerator do
     # public suffix outputs.
     input
     |> String.downcase
-    |> String.lstrip(?.)
+    |> String.trim_leading(".")
   end
   defp public_suffix_output(registrable_domain, _) do
     registrable_domain

--- a/test/public_suffix_test.exs
+++ b/test/public_suffix_test.exs
@@ -125,7 +125,7 @@ defmodule PublicSuffix.PublicSuffixTest do
   defp roundtrip_through_punycoding(domain) do
     domain
     |> PublicSuffix.RulesParser.punycode_domain
-    |> to_char_list
+    |> to_charlist()
     |> :idna.from_ascii
     |> to_string
   end


### PR DESCRIPTION
Here is a list of the deprecations (from
https://hexdocs.pm/elixir/compatibility-and-deprecations.html):

String.strip/1 deprecated in 1.5 replaced with String.trim/1 (available in 1.3)
String.rstrip/1 deprecated in 1.5 replaced with Strim.trim_trailing/1 (available from 1.3)
String.lstrip/1 deprecated in 1.5 replaced with Strim.trim_leading/1 (available from 1.3)
Kernel.to_char_list/1 deprecated in v1.5 replaced with Kernel.to_charlist (available in 1.3)
Enum.partion/2 deprecated in v1.6 replaced with Enum.split_with/2 (available in 1.4)
Stream.chunk/2 deprecated in v1.7 replaced with Stream.chunk_every/2 (available in 1.5)

If we want to maintain support for a lower version of Elixir then we can remove the `Stream.chunk/2` fix to support 1.4 (or likewise `Enum.partition/2` to support v1.3). But in my opinion, 1.5 (released [Jul 24, 2017](https://github.com/elixir-lang/elixir/releases/tag/v1.5.0)) should be good.