### PR TITLE
Bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: elixir
 otp_release:
-  - 18.1
+  - 20.3
 elixir:
-  - 1.2.6
-  - 1.3.2
+  - 1.4.5
+  - 1.5.3
 script: "script/ci_build"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Unreleased
+
+* Update IDNA to support version 6.0.0
+  * Also bump dev dependecies for earmark and ex_doc
+
+Breaking:
+* Raise minimum Elixir version to 1.4
+
 ### 0.6.0 / 2018-02-28
 [Full Changelog](https://github.com/seomoz/publicsuffix-elixir/compare/v0.5.0...v0.4.0)
 

--- a/lib/public_suffix/rules_parser.ex
+++ b/lib/public_suffix/rules_parser.ex
@@ -56,11 +56,15 @@ defmodule PublicSuffix.RulesParser do
   end
 
   @doc false
+  # We can only convert domain's to punycode so do not pass through operators
+  def punycode_domain("*" <> rule), do: "*" <> punycode_domain(rule)
+  def punycode_domain("!" <> rule), do: "!" <> punycode_domain(rule)
+
   def punycode_domain(rule) do
     rule
     |> :unicode.characters_to_list
-    |> :idna.to_ascii
-    |> to_string
+    |> :idna.encode(uts46: true)
+    |> to_string()
   end
 
   defp to_domain_label_map(rules, type) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PublicSuffix.Mixfile do
   def project do
     [app: :public_suffix,
      version: "0.6.0",
-     elixir: "~> 1.2",
+     elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule PublicSuffix.Mixfile do
 
   defp deps do
     [
-      {:idna, ">= 1.2.0 and < 6.0.0"},
+      {:idna, ">= 1.2.0 and < 7.0.0"},
       # ex_doc and earmark are necessary to publish docs to hexdocs.pm.
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,9 @@
 %{
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/public_suffix_test.exs
+++ b/test/public_suffix_test.exs
@@ -126,7 +126,7 @@ defmodule PublicSuffix.PublicSuffixTest do
     domain
     |> PublicSuffix.RulesParser.punycode_domain
     |> to_char_list
-    |> :idna.from_ascii
+    |> :idna.decode(uts46: true)
     |> to_string
   end
 end


### PR DESCRIPTION
earmark 0.2.1 -> 1.3.1
ex_doc 0.11.5 -> 0.19.3
idna 5.1.0 -> 6.0.0

Judging by the idna changelog, there aren't any actual breaking changes
in 6.0.0:
https://github.com/benoitc/erlang-idna/blob/3eb54ccbfa6fb917c0f4ca9197da337ad888ffe0/CHANGELOG

Turns out that idna 6.0.0 has some breaking changes so adjust how
punycode conversions are done

References:
* https://github.com/benoitc/erlang-idna/pull/28
* https://github.com/benoitc/erlang-idna/issues/26#issuecomment-466939431

Note: the `test "compiles using a newly fetched copy of the rules file if so configured"` seems to use a version of `publicsuffix-elixir` from the `deps` directory so I couldn't get it to pass locally.